### PR TITLE
Keep heroku cli node_modules stuff

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,5 +4,5 @@
 BUILD_DIR=$1
 
 echo "-----> Deleting node_modules directories"
-rm -rf $BUILD_DIR/node_modules
-rm -rf $BUILD_DIR/ui/node_modules 
+rm -rf "$BUILD_DIR/node_modules"
+rm -rf "$BUILD_DIR/ui/node_modules" 

--- a/bin/compile
+++ b/bin/compile
@@ -3,5 +3,6 @@
 
 BUILD_DIR=$1
 
-echo "-----> Deleting the node_modules directory"
-find $BUILD_DIR -name 'node_modules' -type d -prune -print -exec rm -rf '{}' \;
+echo "-----> Deleting node_modules directories"
+rm -rf $BUILD_DIR/node_modules
+rm -rf $BUILD_DIR/ui/node_modules 


### PR DESCRIPTION
This PR specifies which node_modules directories to remove rather than the "find" command that was removing the heroku cli stuff that we still need.